### PR TITLE
ACCEL-549: Class name fix.

### DIFF
--- a/openassessment/templates/openassessmentblock/instructor_dashboard/oa_listing.html
+++ b/openassessment/templates/openassessmentblock/instructor_dashboard/oa_listing.html
@@ -22,7 +22,7 @@
     <div class="open-response-assessment-content">
         <div class="open-response-assessment-summary"></div>
         <hr/>
-        <div class="open-response-assessmentora-cohort-select-main-table"></div>
+        <div class="open-response-assessment-main-table"></div>
     </div>
     <div class="open-response-assessment-item">
         <div class="open-response-assessment-item-breadcrumbs"></div>


### PR DESCRIPTION
**Description**: Correcting my own diversion. Obviously, in the past PR, I accidentally changed the name of the Html class, which became a fatal error for rendering the ora report. It was very difficult to find and understand. This happens, but still very offensive and unpleasant.

**Youtrack**: https://youtrack.raccoongang.com/issue/ACCEL-549

**Reviewers**:
[@idegtiarov ]

**Post merge**:
[+] Delete working branch (if not needed anymore)

**NOTE**: After merging of the PR DO NOT forget to create a new tag version.