### PR TITLE
fix: [SkillFacatory2035-1984] fix situation when users cannot check responses of other students if subsection due date has expired

### DIFF
--- a/openassessment/xblock/peer_assessment_mixin.py
+++ b/openassessment/xblock/peer_assessment_mixin.py
@@ -244,8 +244,6 @@ class PeerAssessmentMixin(object):
                 context_dict["peer_file_urls"] = self.get_download_urls_from_submission(peer_sub)
             else:
                 path = 'openassessmentblock/peer/oa_peer_turbo_mode_waiting.html'
-        elif reason == 'due' and problem_closed:
-            path = 'openassessmentblock/peer/oa_peer_closed.html'
         elif reason == 'start' and problem_closed:
             context_dict["peer_start"] = start_date
             path = 'openassessmentblock/peer/oa_peer_unavailable.html'

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.2.8',
+    version='2.2.9',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
**Description:**
* fixes situation when users cannot check responses of other students in `peer assessment` if subsection due date has expired;
* updates version of `edx-ora2` plugin from 2.2.8 to 2.2.9.

**YouTrack:** https://youtrack.raccoongang.com/issue/SkillFacatory2035-1984

**Related MR:** [skillfactory/edx-platform]()

**Merge checklist:**

* [ ] All reviewers approved
* [ ] CI build is green
* [x] Demo status: OK
* [ ] All related documentation is updated
* [ ] DevOps notes added

**Post-Merge:**
- [x] Create `rg-v.2.2.9-skillfactory` tag matching the new version number. (Will be made after merge)