### PR TITLE
[SkillFacatory2035-2373] fix importing ora with self assessment

### DIFF
--- a/openassessment/xblock/xml.py
+++ b/openassessment/xblock/xml.py
@@ -571,7 +571,7 @@ def parse_assessments_xml(assessments_root):
                 raise UpdateFromXmlError('The "must_be_graded_by" value must be a positive integer.')
 
         # Assessment required
-        if 'required' in assessment.attrib:
+        if 'required' in assessment.attrib and assessment_dict['name'] != 'self-assessment':
 
             # Staff assessment is the only type to use an explicit required marker
             if assessment_dict['name'] != 'staff-assessment':

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='2.2.9',
+    version='2.3.0',
     author='edX',
     url='http://github.com/edx/edx-ora2',
     description='edx-ora2',


### PR DESCRIPTION
**TL;DR -** [ fix importing ora with self assessment ]

Uoutrack: [SkillFacatory2035-2373](https://youtrack.raccoongang.com/issue/SkillFacatory2035-2373)

**What changed?**

- [ fix importing ora with self assessment]

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
